### PR TITLE
fix: Load resource files from releases

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ variable "olm_version" {
 
 locals {
   olm_base_url = format(
-    "https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/%s",
+    "https://github.com/operator-framework/operator-lifecycle-manager/releases/download/%s",
     var.olm_version
   )
   # Make sure dependencies are resolved correctly, this is important in context of terraform destroy to make sure the
@@ -37,11 +37,11 @@ locals {
 }
 
 data "http" "olm_crds" {
-  url = format("%s/deploy/upstream/quickstart/crds.yaml", local.olm_base_url)
+  url = format("%s/crds.yaml", local.olm_base_url)
 }
 
 data "http" "olm" {
-  url = format("%s/deploy/upstream/quickstart/olm.yaml", local.olm_base_url)
+  url = format("%s/olm.yaml", local.olm_base_url)
 }
 
 data "kubectl_file_documents" "olm_crds" {

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ terraform {
 variable "olm_version" {
   type        = string
   description = "Version of the operator lifecycle manager."
-  default     = "v0.18.3"
+  default     = "v0.26.0"
 }
 
 locals {


### PR DESCRIPTION
Files in deploy/upstream/quickstart are not maintained and still contain values for v0.18.3.

FYI: There is no automation in place, a tag has to be created manually.